### PR TITLE
Bugfix: workFile publish

### DIFF
--- a/client/ayon_zbrush/plugins/create/create_workfile.py
+++ b/client/ayon_zbrush/plugins/create/create_workfile.py
@@ -48,7 +48,6 @@ class CreateWorkfile(plugin.ZbrushAutoCreator):
                 "task": task_name,
                 "variant": variant,
                 "folderPath": folder_path,
-                "taskType": task_entity["taskType"],
             }
 
             new_instance = CreatedInstance(
@@ -75,5 +74,4 @@ class CreateWorkfile(plugin.ZbrushAutoCreator):
             )
             current_instance["folderPath"] = folder_path
             current_instance["task"] = task_entity["name"]
-            current_instance["subset"] = product_name
-            current_instance["taskType"] = task_entity["taskType"]
+            current_instance["productName"] = product_name

--- a/client/ayon_zbrush/plugins/create/create_workfile.py
+++ b/client/ayon_zbrush/plugins/create/create_workfile.py
@@ -73,6 +73,7 @@ class CreateWorkfile(plugin.ZbrushAutoCreator):
             product_name = self.get_product_name(
                 variant, task_entity, folder_entity, project_name, host_name
             )
+            current_instance["folderPath"] = folder_path
             current_instance["task"] = task_entity["name"]
             current_instance["subset"] = product_name
             current_instance["taskType"] = task_entity["taskType"]


### PR DESCRIPTION
PR on behalf of a colleague:

Tested with `Core addon` version `0.3.1` and `zbrush addon` version `0.1.0`

Publishing a workfile in Z-brush caused the following error:

```
{
   "type":"error",
   "is_validation_error":false,
   "msg":"unhashable type: 'dict'",
   "filename":"C:\\\\Users\\\\******\\\\AppData\\\\Local\\\\Ynput\\\\AYON\\\\addons\\\\core_0.3.1\\\\ayon_core\\\\plugins\\\\publish\\\\collect_anatomy_instance_data.py",
   "lineno":"170",
   "func":"fill_missing_task_entities",
   "traceback":"Traceback (most recent call last):\\n  File \\""C":\\\\Users\\\\******\\\\AppData\\\\Local\\\\Ynput\\\\AYON\\\\dependency_packages\\\\ayon_2403071252_windows.zip\\\\dependencies\\\\pyblish\\\\plugin.py\\", line 527, in __explicit_process\\n    runner(*args)\\n  File \\""C":\\\\Users\\\\******\\\\AppData\\\\Local\\\\Ynput\\\\AYON\\\\addons\\\\core_0.3.1\\\\ayon_core\\\\plugins\\\\publish\\\\collect_anatomy_instance_data.py\\", line 56, in process\\n    self.fill_missing_task_entities(context, project_name)\\n  File \\""C":\\\\Users\\\\******\\\\AppData\\\\Local\\\\Ynput\\\\AYON\\\\addons\\\\core_0.3.1\\\\ayon_core\\\\plugins\\\\publish\\\\collect_anatomy_instance_data.py\\", line 170, in fill_missing_task_entities\\n    _by_task_name = _by_folder_id.setdefault(_task_name, [])\\nTypeError: unhashable type: 'dict'\\n",
   "instance_id":null
}
```

Updated `client/ayon_zbrush/plugins/create/create_workfile.py`
`CreatedInstance()`,  `data` now takes `task_name` instead of `task_entity` for the `task` attribute

Set `current_instance` `task` to "task name" and added `taskType"
