### PR TITLE
Add client pyproject.toml

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,0 +1,2 @@
+[ayon.runtimeDependencies]
+aiohttp_json_rpc = "*"


### PR DESCRIPTION
Adds pyproject.toml to the client package to create dependency packages. 

The issue was triggered within a local docker environment that is not using the bootstrap and is running with a limited set of add-ons (see below)

The error occurs when launching the ayon launcher, and results in the zbrush add-on failing to load.

![Screenshot_20240625_120851](https://github.com/ynput/ayon-zbrush/assets/2554639/1289192d-34d7-41cf-a62e-f5e9d7163482)

![Screenshot_20240625_121659](https://github.com/ynput/ayon-zbrush/assets/2554639/ef698c75-7871-40b3-ab50-d31c76eaf9a2)
