### PR TITLE
Chore: Use new workfiles API to increment current workfile.

### DIFF
--- a/client/ayon_zbrush/plugins/publish/increment_workfile_version.py
+++ b/client/ayon_zbrush/plugins/publish/increment_workfile_version.py
@@ -1,5 +1,9 @@
+import os
+
 import pyblish.api
+
 from ayon_core.lib import version_up
+from ayon_core.host import IWorkfileHost
 from ayon_core.pipeline import registered_host
 
 
@@ -12,7 +16,33 @@ class IncrementWorkfileVersion(pyblish.api.ContextPlugin):
     families = ["workfile"]
 
     def process(self, context):
-        host = registered_host()
-        path = context.data["currentFile"]
-        self.log.info(f"Increment and save workfile: {path}")
-        host.save_workfile(version_up(path))
+        host: IWorkfileHost = registered_host()
+        current_filepath: str = host.get_current_workfile()
+
+        try:
+            from ayon_core.pipeline.workfile import save_next_version
+            from ayon_core.host.interfaces import SaveWorkfileOptionalData
+
+            current_filename = os.path.basename(current_filepath)
+            save_next_version(
+                description=(
+                    f"Incremented by publishing from {current_filename}"
+                ),
+                # Optimize the save by reducing needed queries for context
+                prepared_data=SaveWorkfileOptionalData(
+                    project_entity=context.data["projectEntity"],
+                    project_settings=context.data["project_settings"],
+                    anatomy=context.data["anatomy"],
+                )
+            )
+            new_filepath = host.get_current_workfile()
+        except ImportError:
+            # Backwards compatibility before ayon-core 1.5.0
+            self.log.debug(
+                "Using legacy `version_up`. Update AYON core addon to "
+                "use newer `save_next_version` function."
+            )
+            new_filepath = version_up(current_filepath)
+            host.save_workfile(new_filepath)
+
+        self.log.debug(f"Incremented workfile to: {new_filepath}")


### PR DESCRIPTION
## Changelog Description

When incrementing the workfile during publish, use the new context-based workfile API so that the current author information is stored with the saved file.

## Additional review information

<img width="260" height="113" alt="image" src="https://github.com/user-attachments/assets/4f20a81e-e437-46d2-a0cf-66092b20d8de" />

_screenshot from maya_

Requires ayon-core 1.5.0 to test the added comment (aka artist note) and the author data to come through.

## Testing notes:

1. Publishing should work
2. Workfile should be incremented
3. Workfile should show the author of the publish 
4. Workfile should have 'artist note' set: "Incremented by publishing."
