### PR TITLE
Create: Use kwargs to call product name functions

### DIFF
--- a/client/ayon_zbrush/plugins/create/create_workfile.py
+++ b/client/ayon_zbrush/plugins/create/create_workfile.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 """Creator plugin for creating workfiles."""
-import ayon_api
 from ayon_core.pipeline import CreatedInstance
+
 from ayon_zbrush.api import plugin
+
 
 class CreateWorkfile(plugin.ZbrushAutoCreator):
     """Workfile auto-creator."""


### PR DESCRIPTION
## Changelog Description
Use kwargs to call product name functions and use cached data to call them if possible.

## Additional review information
This is preparation for future change in `get_product_name` functionality and update of already added change in `get_product_name` method.

## Testing notes:
1. Product names are calculated correctly.
