### PR TITLE
Create: Remove dynamic data

### DIFF
--- a/client/ayon_zbrush/api/plugin.py
+++ b/client/ayon_zbrush/api/plugin.py
@@ -74,21 +74,6 @@ class ZbrushCreator(Creator, ZbrushCreatorBase):
         for instance in instances:
             self._remove_instance_from_context(instance)
 
-    # Helper methods (this might get moved into Creator class)
-    def get_dynamic_data(self, *args, **kwargs):
-        # Change asset and name by current workfile context
-        create_context = self.create_context
-        folder_path = create_context.get_current_folder_path()
-        task_name = create_context.get_current_task_name()
-        output = {}
-        if folder_path:
-            folder_name = folder_path.rsplit("/")[-1]
-            output["asset"] = folder_name
-            output["folder"] = {"name": folder_name}
-            if task_name:
-                output["task"] = task_name
-        return output
-
     def _store_new_instance(self, new_instance):
         instances_data = self.host.list_instances()
         instances_data.append(new_instance.data_to_store())

--- a/client/ayon_zbrush/plugins/create/create_workfile.py
+++ b/client/ayon_zbrush/plugins/create/create_workfile.py
@@ -52,7 +52,10 @@ class CreateWorkfile(plugin.ZbrushAutoCreator):
             }
 
             new_instance = CreatedInstance(
-                self.product_type, product_name, data, self
+                product_type=self.product_type,
+                product_name=product_name,
+                data=data,
+                creator=self,
             )
             instances_data = self.host.list_instances()
             instances_data.append(new_instance.data_to_store())

--- a/package.py
+++ b/package.py
@@ -8,6 +8,6 @@ client_dir = "ayon_zbrush"
 
 ayon_server_version = ">=1.1.2"
 ayon_required_addons = {
-    "core": ">0.3.2",
+    "core": ">=1.7.0",
 }
 ayon_compatible_addons = {}


### PR DESCRIPTION
## Changelog Description
Remove dynamic data that do add folder to template data for product name.

## Additional review information
Since ayon-core 1.7.0 it is possible to use folder in product name. Bumped required version of ayon-core in package.py. Also use kwargs for `CreatedInstance`.

## Testing notes:
1. Zbrush creation still works even if `{folder[name]}` is in produt name tempalte.
