### PR TITLE
Create: Remove kwargs from CreatedInstance

### DIFF
--- a/client/ayon_zbrush/api/plugin.py
+++ b/client/ayon_zbrush/api/plugin.py
@@ -41,10 +41,10 @@ class ZbrushCreatorBase:
 class ZbrushCreator(Creator, ZbrushCreatorBase):
     def create(self, product_name, instance_data, pre_create_data):
         new_instance = CreatedInstance(
-            product_type=self.product_type,
-            product_name=product_name,
-            data=instance_data,
-            creator=self,
+            self.product_type,
+            product_name,
+            instance_data,
+            self,
         )
         self._store_new_instance(new_instance)
 

--- a/client/ayon_zbrush/api/plugin.py
+++ b/client/ayon_zbrush/api/plugin.py
@@ -41,7 +41,7 @@ class ZbrushCreatorBase:
 class ZbrushCreator(Creator, ZbrushCreatorBase):
     def create(self, product_name, instance_data, pre_create_data):
         new_instance = CreatedInstance(
-            self.product_type,
+            self.product_base_type,
             product_name,
             instance_data,
             self,

--- a/client/ayon_zbrush/plugins/create/create_workfile.py
+++ b/client/ayon_zbrush/plugins/create/create_workfile.py
@@ -52,10 +52,10 @@ class CreateWorkfile(plugin.ZbrushAutoCreator):
             }
 
             new_instance = CreatedInstance(
-                product_type=self.product_type,
-                product_name=product_name,
-                data=data,
-                creator=self,
+                self.product_type,
+                product_name,
+                data,
+                self,
             )
             instances_data = self.host.list_instances()
             instances_data.append(new_instance.data_to_store())

--- a/client/ayon_zbrush/plugins/create/create_workfile.py
+++ b/client/ayon_zbrush/plugins/create/create_workfile.py
@@ -52,7 +52,7 @@ class CreateWorkfile(plugin.ZbrushAutoCreator):
             }
 
             new_instance = CreatedInstance(
-                self.product_type,
+                self.product_base_type,
                 product_name,
                 data,
                 self,


### PR DESCRIPTION
## Changelog Description
Remove kwargs from `CreatedInstance` and use `product_base_type` instead of `product_type`.

## Additional review information
Revert changes from https://github.com/ynput/ayon-zbrush/pull/35. We want to do oposite, to be able to replace `product_type` with `product_base_type`.

## Testing notes:
1. Nothing should change.
