### PR TITLE
🏛️Product base types: Product types and base types

### DIFF
--- a/client/ayon_zbrush/api/plugin.py
+++ b/client/ayon_zbrush/api/plugin.py
@@ -40,8 +40,12 @@ class ZbrushCreatorBase:
 
 class ZbrushCreator(Creator, ZbrushCreatorBase):
     def create(self, product_name, instance_data, pre_create_data):
+        product_type = instance_data.get("productType")
+        if not product_type:
+            product_type = self.product_base_type
         new_instance = CreatedInstance(
-            product_type=self.product_type,
+            product_base_type=self.product_base_type,
+            product_type=product_type,
             product_name=product_name,
             data=instance_data,
             creator=self,

--- a/client/ayon_zbrush/api/plugin.py
+++ b/client/ayon_zbrush/api/plugin.py
@@ -39,6 +39,9 @@ class ZbrushCreatorBase:
 
 
 class ZbrushCreator(Creator, ZbrushCreatorBase):
+    settings_category = "zbrush"
+    skip_discovery = True
+
     def create(self, product_name, instance_data, pre_create_data):
         product_type = instance_data.get("productType")
         if not product_type:
@@ -86,6 +89,9 @@ class ZbrushCreator(Creator, ZbrushCreatorBase):
 
 
 class ZbrushAutoCreator(AutoCreator, ZbrushCreatorBase):
+    settings_category = "zbrush"
+    skip_discovery = True
+
     def collect_instances(self):
         self._collect_instances()
 

--- a/client/ayon_zbrush/plugins/create/create_model.py
+++ b/client/ayon_zbrush/plugins/create/create_model.py
@@ -8,8 +8,8 @@ class CreateModel(plugin.ZbrushCreator):
     """Creator plugin for Model."""
     identifier = "io.ayon.creators.zbrush.model"
     label = "Model"
-    product_type = "model"
     product_base_type = "model"
+    product_type = product_base_type
     icon = "cube"
     export_format = "obj"
 
@@ -20,10 +20,11 @@ class CreateModel(plugin.ZbrushCreator):
             if key in pre_create_data:
                 creator_attributes[key] = pre_create_data[key]
 
-        super(CreateModel, self).create(
+        super().create(
             product_name,
             instance_data,
-            pre_create_data)
+            pre_create_data
+        )
 
     def get_instance_attr_defs(self):
         export_format_enum = ["abc", "fbx", "obj"]

--- a/client/ayon_zbrush/plugins/create/create_workfile.py
+++ b/client/ayon_zbrush/plugins/create/create_workfile.py
@@ -9,8 +9,8 @@ class CreateWorkfile(plugin.ZbrushAutoCreator):
     """Workfile auto-creator."""
     identifier = "io.ayon.creators.zbrush.workfile"
     label = "Workfile"
-    product_type = "workfile"
     product_base_type = "workfile"
+    product_type = product_base_type
     icon = "fa5.file"
 
     default_variant = "Main"
@@ -44,6 +44,7 @@ class CreateWorkfile(plugin.ZbrushAutoCreator):
                 task_entity=task_entity,
                 variant=variant,
                 host_name=host_name,
+                product_type=self.product_base_type,
             )
             data = {
                 "task": task_name,
@@ -52,7 +53,8 @@ class CreateWorkfile(plugin.ZbrushAutoCreator):
             }
 
             new_instance = CreatedInstance(
-                product_type=self.product_type,
+                product_base_type=self.product_base_type,
+                product_type=self.product_base_type,
                 product_name=product_name,
                 data=data,
                 creator=self,

--- a/client/ayon_zbrush/plugins/load/load_mesh.py
+++ b/client/ayon_zbrush/plugins/load/load_mesh.py
@@ -9,7 +9,8 @@ from ayon_zbrush.api.lib import execute_zscript, remove_subtool
 class MeshLoader(load.LoaderPlugin):
     """Zbrush Model Loader."""
 
-    product_types = {"model"}
+    product_base_types = {"model"}
+    product_types = product_base_types
     representations = {"abc", "fbx", "obj", "ma"}
     order = -9
     icon = "code-fork"

--- a/package.py
+++ b/package.py
@@ -8,6 +8,6 @@ client_dir = "ayon_zbrush"
 
 ayon_server_version = ">=1.1.2"
 ayon_required_addons = {
-    "core": ">=1.7.0",
+    "core": ">=1.8.0",
 }
 ayon_compatible_addons = {}

--- a/server/settings/create.py
+++ b/server/settings/create.py
@@ -1,0 +1,34 @@
+from ayon_server.settings import (
+    BaseSettingsModel,
+    SettingsField,
+)
+
+
+class ProductTypeItemModel(BaseSettingsModel):
+    _layout = "compact"
+    product_type: str = SettingsField(
+        title="Product type",
+        description="Product type name"
+    )
+    label: str = SettingsField(
+        "",
+        title="Label",
+        description="Label to show in UI for the product type"
+    )
+
+
+class BaseCreatePluginModel(BaseSettingsModel):
+    product_type_items: list[ProductTypeItemModel] = SettingsField(
+        default_factory=list,
+        title="Product type items",
+        description=(
+            "Optional list of product types this plugin can create. "
+        ),
+    )
+
+
+class CreatePluginsModel(BaseSettingsModel):
+    CreateModel: BaseCreatePluginModel = SettingsField(
+        default_factory=BaseCreatePluginModel,
+        title="Create Model",
+    )

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -1,9 +1,15 @@
 from ayon_server.settings import BaseSettingsModel, SettingsField
 
+from .create import CreatePluginsModel
+
 
 class ZbrushSettings(BaseSettingsModel):
     stop_timer_on_application_exit: bool = SettingsField(
         title="Stop timer on application exit")
+    create: CreatePluginsModel = SettingsField(
+        default_factory=CreatePluginsModel,
+        title="Create plugins"
+    )
 
 
 DEFAULT_VALUES = {


### PR DESCRIPTION
## Changelog Description
Use product base types and add support for product types used as aliases.

## Additional review information
Zbrush is fully using product base type as "pipeline" type and product type as an alias. Load plugins define `product_base_types` for filtering, create plugins do define `product_base_type` and the whole logic is expecting that product base type is being used in the system.

## Testing notes:
1. Define product types for a create plugin.
2. Create an instance with the product type.
3. Product name should use the product type in name (if template defines that).
4. Publish the instance.
5. Loader tool should show the product type and product base type in UI.